### PR TITLE
Fix formatting and output of root dir location

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ async function main() {
             console.log(`\ndeleting temp data\n`)
             execSync(`rm -rf ${escapeForShell(path.resolve(`./savedData/${directoryName}`))}`);
         } else {
-            console.log(`\nall data has been saved locally in ${path.resolve(directoryName)}\nyou can run 'npm run prune' to delete the data if you don't need it anymore
+            console.log(`\nall data has been saved locally in ${path.resolve(`./savedData/${directoryName}`)}\nyou can run 'npm run prune' to delete the data if you don't need it anymore
             `)
         }
 

--- a/index.js
+++ b/index.js
@@ -47,9 +47,9 @@ async function main() {
     console.log(`found config @ ${configPath}\n`);
 
     //create a root folder for everything
-    const now = dayjs().format('YYYY-MM-DD HH.MM.ss.SSS');
+    const now = dayjs().format('YYYY-MM-DD_HH.MM.ss.SSS');
     const randomNum = getRandomInt(420);
-    let directoryName = `${config.source.name} ${now} ${randomNum}`;
+    let directoryName = `${config.source.name}_${now}_${randomNum}`;
     try {
         if (config.source.options.path_to_data) {
             directoryName = path.resolve(`./${config.source.options.path_to_data}`)

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ async function main() {
     console.log(`found config @ ${configPath}\n`);
 
     //create a root folder for everything
-    const now = dayjs().format('YYYY-MM-DD HH.MM.ss.SSS A');
+    const now = dayjs().format('YYYY-MM-DD HH.MM.ss.SSS');
     const randomNum = getRandomInt(420);
     let directoryName = `${config.source.name} ${now} ${randomNum}`;
     try {


### PR DESCRIPTION
Before:
```
all data has been saved locally in /Users/marshall/src/ak--47/toMixpanel/amplitude 2023-07-24 14.07.37.426 PM 30
```

Outputted value is wrong because it's missing `savedData/` in the path:
```
% ls '/Users/marshall/src/ak--47/toMixpanel/amplitude 2023-07-24 14.07.37.426 PM 30'         
ls: /Users/marshall/src/ak--47/toMixpanel/amplitude 2023-07-24 14.07.37.426 PM 30: No such file or directory
```

After:
```
all data has been saved locally in /Users/marshall/src/ak--47/toMixpanel/savedData/amplitude_2023-07-24_16.07.22.211_164
```

The path doesn't need to be quoted because it uses `_` and it correctly includes the `savedData/` part of the path:
```
% ls /Users/marshall/src/ak--47/toMixpanel/savedData/amplitude_2023-07-24_16.07.22.211_164
downloaded	json		logs		transformed	unzip
```